### PR TITLE
Change the project layout a little

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "MusicBot"]
+	path = MusicBot
+	url = https://github.com/jagrosh/MusicBot.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,9 @@
 
 FROM maven AS build
 
-RUN microdnf install git
-
-RUN git clone https://github.com/jagrosh/MusicBot
-
 WORKDIR /MusicBot
-
+COPY . .
 RUN mvn package
-
 
 # Run Stage
 
@@ -19,12 +14,10 @@ WORKDIR /MusicBot
 
 COPY --from=build /MusicBot/target/JMusicBot-Snapshot-All.jar /MusicBot/JMusicBot.jar
 
-RUN groupadd -r musicbot && useradd -g musicbot musicbot
-
-RUN chown -R musicbot:musicbot /MusicBot
+RUN groupadd -r musicbot && \
+    useradd -g musicbot musicbot && \
+    chown -R musicbot:musicbot /MusicBot
 
 USER musicbot
 
 CMD ["java", "-Dnogui=true", "-jar", "JMusicBot.jar"]
-
-

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 Builds and runs the latest Version of [JMusicBot](https://github.com/jagrosh/MusicBot).
 _A cross-platform Discord music bot with a clean interface, and that is easy to set up and run yourself!_
 
+Clone this repository using the following command so you also get the submodule:
+```
+git clone --recursive <this-repo-url>
+```
+
 ## Image (Dockerfile)
 2-Stage Build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,21 @@
+---
 version: "3.3"
 
-services: 
-  
+services:
+
   musicbot_alpha:
-    build: .
-    volumes: 
+    build: &buildinstructions
+      context: ./src
+      dockerfile: ../Dockerfile
+    volumes:
       - ./config_alpha.txt:/MusicBot/config.txt
-  
+
   musicbot_beta:
-    build: .
-    volumes: 
+    build: *buildinstructions
+    volumes:
       - ./config_beta.txt:/MusicBot/config.txt
-    
+
   musicbot_gamma:
-    build: .
-    volumes: 
+    build: *buildinstructions
+    volumes:
       - ./config_gamma.txt:/MusicBot/config.txt
-      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
 
   musicbot_alpha:
     build: &buildinstructions
-      context: ./src
+      context: ./MusicBot
       dockerfile: ../Dockerfile
     volumes:
       - ./config_alpha.txt:/MusicBot/config.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ version: "3.3"
 services:
 
   musicbot_alpha:
+    restart: always
     build: &buildinstructions
       context: ./MusicBot
       dockerfile: ../Dockerfile
@@ -11,11 +12,13 @@ services:
       - ./config_alpha.txt:/MusicBot/config.txt
 
   musicbot_beta:
+    restart: always
     build: *buildinstructions
     volumes:
       - ./config_beta.txt:/MusicBot/config.txt
 
   musicbot_gamma:
+    restart: always
     build: *buildinstructions
     volumes:
       - ./config_gamma.txt:/MusicBot/config.txt


### PR DESCRIPTION
The included git clone command in the `Dockerfile` hurts two principles of docker:
1. _reproducibilty_ people cloning this can not expect one fixed result
2. _cacheability_ the layer cannot possibly (rightly) be cached

This is changed by introducing a Submodule with the code, copying it to the buildstage and then go on as before.


- change the dockerfile layout
- :package: enable some reuse in the composefile
- add the Sourcecode as git submodule to ensure reproducibility
- change readme accordingly
